### PR TITLE
Update ATS_EX.ino

### DIFF
--- a/ATS_EX/ATS_EX.ino
+++ b/ATS_EX/ATS_EX.ino
@@ -573,15 +573,15 @@ void SettingParamToUI(char* buf, uint8_t idx)
         {
             if (param == 0)
             {
-                buf[0] = '1';
-                buf[1] = '0';
-                buf[2] = '0';
+                buf[0] = 'F';
+                buf[1] = 'S';
+                buf[2] = 'P';
             }
             else
             {
-                buf[0] = '5';
-                buf[1] = '0';
-                buf[2] = '%';
+                buf[0] = 'H';
+                buf[1] = 'S';
+                buf[2] = 'P';
             }
         }
         else


### PR DESCRIPTION
The readings "100" and "50%" for the CPU speed are a bit inconsistent, so I would suggest to use "FSP" ("FullSPeed") and "HSP" ("HalfSPeed"). Maybe "HSP" ("HighSPeed") and "LSP" ("LowSPeed") could also be a good choice.

Regards, Thorsten