### PR TITLE
bugfix: seek FM stations

### DIFF
--- a/ATS_EX/ATS_EX.ino
+++ b/ATS_EX/ATS_EX.ino
@@ -417,13 +417,11 @@ void showFrequency(bool cleanDisplay = false)
 void showFrequencySeek(uint16_t freq)
 {
     g_currentFrequency = freq;
-    delay(10);
     if (g_currentMode == FM)
     {
         //Fix random 10th KHz fraction
         freq = (freq / 10) * 10;
         g_currentFrequency = freq;
-        g_si4735.setFrequency(g_currentFrequency);
     }
     else
         g_currentFrequency = g_si4735.getFrequency();

--- a/ATS_EX/ATS_EX.ino
+++ b/ATS_EX/ATS_EX.ino
@@ -1758,8 +1758,6 @@ void loop()
             g_SettingEditing = !g_SettingEditing;
             DrawSetting(g_SettingSelected, true);
         }
-        else if (g_displayRDS)
-            g_rdsSwitchPressed = true;
         else if (isSSB() || g_Settings[SettingsIndex::ScanSwitch].param == 0)
         {
             if (!g_settingsActive)
@@ -1771,6 +1769,8 @@ void loop()
         //Seek in SSB/CW is not allowed
         else if (g_currentMode == FM || g_currentMode == AM)
             doSeek();
+        else if (g_displayRDS)
+            g_rdsSwitchPressed = true;
     }
 
     //This is a hack, it allows SHORTPRESS and LONGPRESS events


### PR DESCRIPTION
Hi.
FM station search works fine, but
after a successful station search, the frequency changes using the method

`g_si4735.setFrequency(g_currentFrequency);`

and the found station is lost.
After deleting this line, the found frequency doesn't change.

Fixed in the second commit
When RDS is enabled, the station search doesn't start because condition 

`else if (g_displayRDS)` 

is earlier than 
```
else if (g_currentMode == FM || g_currentMode == AM)
  doSeek();
```